### PR TITLE
Add order support for JSON animation

### DIFF
--- a/src/core/components/wrapper/JsonAnimationWrapper.tsx
+++ b/src/core/components/wrapper/JsonAnimationWrapper.tsx
@@ -4,6 +4,7 @@ import { BaseAnimationWrapper } from './BaseAnimationWrapper';
 import { JsonAnimationConfig, TransformDef } from '../../data/JsonAnimationConfig';
 import { AnimationWrapperProps } from '../../Types';
 import getEasingFunction from "../Utils";
+import { OrderType } from '../../data/Enums';
 
 
 export interface JsonAnimationProps extends AnimationWrapperProps {
@@ -100,12 +101,12 @@ export class JsonAnimationWrapper extends BaseAnimationWrapper<JsonAnimationProp
     }
 
     private _updateCompositeAnimation(props: JsonAnimationProps): void {
-        const animationSequence: Animated.CompositeAnimation[] = [];
+        const animationList: Animated.CompositeAnimation[] = [];
         if (Array.isArray(props.animationConfig.animationConfig)) {
             for (let i = 0; i < props.animationConfig.animationConfig.length; i++) {
                 const animationDef = props.animationConfig.animationConfig[i];
                 if (this._animation) {
-                    animationSequence.push(Animated.timing(this._animation[i], {
+                    animationList.push(Animated.timing(this._animation[i], {
                         toValue: 1,
                         duration: animationDef.duration,
                         easing: getEasingFunction(animationDef.interpolation),
@@ -113,7 +114,10 @@ export class JsonAnimationWrapper extends BaseAnimationWrapper<JsonAnimationProp
                     }));
                 }
             }
-            this._compositeAnimation = Animated.sequence(animationSequence);
+            this._compositeAnimation =
+              props.animationConfig.orderType === OrderType.PARALLEL
+                ? Animated.parallel(animationList)
+                : Animated.sequence(animationList);
         } else {
             const animationDef = props.animationConfig.animationConfig;
             if (this._animation) {

--- a/src/core/data/Enums.ts
+++ b/src/core/data/Enums.ts
@@ -15,3 +15,8 @@ export enum AnimationType {
     WIGGLE = "WIGGLE",
     JSON = "JSON"
 }
+
+export enum OrderType {
+    SEQUENCE = 'SEQUENCE',
+    PARALLEL = 'PARALLEL'
+}

--- a/src/core/data/JsonAnimationConfig.ts
+++ b/src/core/data/JsonAnimationConfig.ts
@@ -1,4 +1,5 @@
 import BaseAnimationConfig from "./BaseAnimationConfig"
+import { OrderType } from "./Enums";
 
 export type TransformType = "scale"
     | "opacity"
@@ -33,7 +34,8 @@ export type EasingType = "linear"
 ;
 
 export interface JsonAnimationConfig extends BaseAnimationConfig {
-    animationConfig: AnimationDef | AnimationDef[] 
+    animationConfig: AnimationDef | AnimationDef[],
+    orderType?: OrderType
 }
 
 /**


### PR DESCRIPTION
When we pass multiple Animation definitions in case of JSON Animation Config, there was no support to run the animation in parallel. Existing implementation ran Animated.Sequence. This PR is to add support to define the order of the animation when multiple Animation Definitions present. 