### PR TITLE
fix: set animation value to final offset on finish animation for slide animation

### DIFF
--- a/src/core/components/wrapper/SlideAnimationWrapper.tsx
+++ b/src/core/components/wrapper/SlideAnimationWrapper.tsx
@@ -37,6 +37,7 @@ export class SlideAnimationWrapper extends BaseAnimationWrapper<SlideAnimationPr
 
     public finishAnimation(): void {
         this.stopAnimation();
+        this.translate.setValue(this._getFinalTranslateValue(this.props));
     }
 
     protected renderAnimation(content: React.ReactNode): React.ReactNode {


### PR DESCRIPTION
When using slideAnimation if we call the finishAnimation callback, the animations stops but does not reach the final view.